### PR TITLE
Clarifying waffle.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+Repo Issues in Ready on Waffle.io  
 [![Stories in Ready](https://badge.waffle.io/OpenDataSTL/opendatastl.github.io.png?label=ready&title=Ready)](https://waffle.io/OpenDataSTL/opendatastl.github.io)
 # Jekyll Now
 


### PR DESCRIPTION
adding some text to clarify what the waffle-io badge at the type of the readme represents